### PR TITLE
Added conditional ability to Trigger a child pipeline before waiting

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,36 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 # <<<----- ADD NEW VERSIONS HERE
 
-## 1.2.2 - (August 04, 2020)
+## 2.0.0 - (August 05, 2020)
 ### Added
-- Fixed licence information
+- Conditional Ability to Trigger a child pipeline before waiting for it.
+### Changed
+- Updated Documentation.
+
+## 1.2.2 - (August 04, 2020)
+### Changed
+- Fixed licence information.
 
 ## 1.2.1 - (August 04, 2020)
-### Added
-- Fixed a bug with the publish buildspec
+### Changed
+- Fixed a bug with the publish buildspec.
 
 ## 1.2.0 - (August 04, 2020)
 ### Added
-- Auto-Publish to AWS Serverless Application Repo
+- Auto-Publish to AWS Serverless Application Repo.
 
 ## 1.1.2 - (July 22, 2020)
 ### Changed
-- Fixed coverage report for SonarCloud
+- Fixed coverage report for SonarCloud.
 
 ## 1.1.1 - (July 21, 2020)
 ### Changed
-- Added auto tagging workflow
-- Updated PR template
+- Added auto tagging workflow.
+- Updated PR template.
 
 ## 1.1.0 - (July 05, 2020)
 ### Added
-- Enabled Mutation Tests with Stryker
-    - Added Mutation Testing Score Badge to README
-- Enabled Jest-Junit to export test reports
+- Enabled Mutation Tests with Stryker.
+    - Added Mutation Testing Score Badge to README.
+- Enabled Jest-Junit to export test reports.
 ### Changed
-- Updated Jest Unit Tests
-- Updated Packages
+- Updated Jest Unit Tests.
+- Updated Packages.
 
 ## 🚀 1.0.0 - (Aug 15, 2018)
 ### Initial
-- Pipeline Monitor lambda released under closed source
+- Pipeline Monitor lambda released under closed source.

--- a/README.md
+++ b/README.md
@@ -11,60 +11,259 @@
 
 <p align="center">
     <a href="#overview">Overview</a> |
-	<a href="#getting-started">Getting Started</a> |
-	<a href="#invoking-the-lambda">Invoking the Lambda</a> |
+    <a href="#getting-started">Getting Started</a> |
+    <a href="#deploying-the-lambda">Deploying the Lambda</a> |
+    <a href="#permissions">Permissions</a> |
+    <a href="#invoking-the-lambda">Invoking the Lambda</a> |
+    <a href="#contributing">Contributing</a> |
   	<a href="#authors">Authors</a> |
   	<a href="#licence">Licence</a>
 </p>
 
 ## Overview
+
+This lambda provides a waiter for an AWS CodePipeline to wait for another AWS CodePipeline. The invoking pipeline can invoke this lambda which will then wait for a target pipeline to complete execution or fail execution. The lambda uses a [Continuation Token](https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-invoke-lambda-function.html) that it returns to the Invoking CodePipeline to get around the 15 minute lambda execution duration. In essence, this acts as a built in polling mechanism within CodePipeline.
+
+Once the waiter has been invoked from the invoking pipeline, the invoking pipeline will stay in progress and wait for the target pipeline to complete. If the target pipeline fails instead of completing successfully, then this lambda will return a failure signal to the invoking pipeline which will also then fail. This lambda can therefore be considered as a way to mirror one pipeline's state to another.
+
+### Use Cases
+* This can be useful to resolve dependencies between multiple pipelines.
+  For example, a CodePipeline that needs to deploy a front-end application may want to ensure that the pipeline deploying the API has been completed successfully. Or a pipeline deploying a microservice may want to ensure that any dependencies are deployed correctly.
+
+* AWS CodePipelines can be used to Deploy other AWS CodePipelines in a parent / child configuration. This is especially useful when you want to have individual pipelines to deploy each of your components, but you also need the ability to do a full scale deployment (into either a new environment or an existing environment) where an ochestration or parent CodePipeline can be used to co-ordinate and drive the child pipelines.
+
+* To co-ordinate with a CodePipeline in another AWS Account to be successful before continuing with the execution. This is a common use case in some multi account AWS estates especially large enterprises.
+
+* To get around the CodePipeline stage limitations when this lambda can be used to chain multiple CodePipelines together to run in sequence.
+
+* If you use a Meta CodePipeline, (i.e. one that continiously deploys configuration changes to your actual CodePipeline), you may wish to use this lambda to wait for a running pipeline to finish before deploying any changes.
+
+* Any other reason why you may want to trigger or wait for another pipeline.
+
+## Getting Started
+### Deploying the Lambda
+
+The lambda needs to be deployed into the same account as your invoking / parent pipeline. It can be deployed through the console from [here](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:673103718481:applications/CodePipeline-Waiter)
+or it can be deployed from Cloudformation.
+
+In order to deploy from CloudFormation, use the following as an example for your template.
+
+```YAML
+
+Description: Deploys CodePipeline Waiter Lambda function from Serverless Application Repo
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+
+Resources:
+  CodePipelineWaiter:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:673103718481:applications/CodePipeline-Waiter
+		SemanticVersion: 2.0.0
+	  # Optional Parameter to control the export name of the nested stack
+	  Parameters:
+	    ExportPrefix: !Ref AWS::StackName
+
+```
+#### Manual Deployment - Not Recommended
+If you choose not to use the lambda from the Servlerless Repo, you can also manually build and deploy the lambda into your own account.
+The following methods are not recommended due to the additional complexity this adds, use at your own discression.
+
+```bash
+# Build the Lambda
+yarn build
+```
+Once built locally you can use one of several of the following methods.
+* [SAM Deploy](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-deploy.html)
+* [SAM Package](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-package.html) or [Cloudformation Package](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html) along with manual deployment of the resulting packaged template.
+* Build and deploy the lambda from an AWS CodePipeline / CodeBuild that's watching this repository
+* Zip the lambda and deploy it manually.
+
+
+### Permissions
+
+In order to re-use this lambda to wait on different pipelines, and in order to adhear to the [principles of least privillege](https://aws.amazon.com/blogs/security/tag/least-privilege/), this lambda needs to assume a role which will give it permissions to trigger / monitor a target pipeline.
+
+This role needs to be created alongside the target pipeline in the same account. It's therefore recommended to use the following template in the same Cloudfromation template that creates your target pipeline.
+
+If you are not using Cloudformation, provision an IAM role with similar permissions and trust policies using a method of your choice.
+
+Although not recommended, you can also provisionally reduce the security provided by this role by allowing a wider trust role and a wider resource permission.
+
+```YAML
+
+  # This Role is to allow the CodePipeline Waiter Lambda to assume it in order to Monitor or Trigger the target pipeline
+  # This role needs to exist in the same account as the target pipeline
+  PipelineWaiterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "example-role-for-target-pipeline-name"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: Allow
+          Principal:
+            AWS:
+              # Note 1: This Lambda always creates an role session with the name "PipelineWaiterLambda"
+              # Note 2: The InvokingAccountID is the account ID where the Lambda resides. It can be the same account or a different account (in the case of cross account pipelines)
+              - !Sub 'arn:aws:sts::${InvokingAccountID}:assumed-role/${RoleNameCreatedByThelambda}/PipelineWaiterLambda'
+          Action:
+            - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub "example-policy-for-target-pipeline-name"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codepipeline:ListPipelines
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - codepipeline:GetPipelineState
+                  - codepipeline:StartPipelineExecution
+                Resource: !Sub 'arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:target-pipeline-name*'
+
+```
+
+### Invoking the Lambda
+
+This Lambda function can only be invoked from an AWS CodePipeline. If you are using CloudFormation use the following stage in your template to invoke the lambda.
+
+If you are not using Cloudformation, provision a CodePipeline stage to invoke the lambda with similar UserParameters using a method of your choice.
+
+```YAML
+
+  ReleasePipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: "example-invoking-pipeline"
+      ...
+      ...
+      ...
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Package-Source
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Version: 1
+                Provider: GitHub
+              OutputArtifacts:
+                - Name: SourceOutput
+              Configuration:
+                Owner: ...
+                Repo: ...
+                Branch: ...
+                OAuthToken: ...
+
+        - Name: Deploy
+            - Name: PipelineWaiter
+              ActionTypeId:
+                Category: Invoke
+                Owner: AWS
+                Version: 1
+                Provider: Lambda
+              Configuration:
+                # The following ExportPrefix is the same as the one above when deploying the lambda.
+                # Defaults to ""
+                FunctionName:
+                  Fn::ImportValue: !Sub ${ExportPrefix}PipelineWaiterLambdaName
+                #The Targetname and AssumeRolearn can be in the same account or in another account.
+                #If they are in another account, they need the correct trust permissions. See above section in readme.
+                UserParameters: |
+                  {
+                  "targetname":"target-pipeline-name", #Required
+                  "assumerolearn":"arn:aws:iam::123456789:role/example-role-for-target-pipeline-name", #Required
+                  "trigger": true #Optional. Defaults to false
+                  }
+              RunOrder: 1
+
+```
+
+#### Inputs
+The Lambda needs to receive the following as an **UserParameters** object on the AWS CodePipeline invocation event.
+
+The lambda expects the following UserParameters to be supplied during invocation:
+```JSON
+{
+    "targetname": "target-pipeline-name",
+	"assumerolearn": "arn:aws:iam::${TargetAccountID}:role/example-role-for-target-pipeline-name",
+	"trigger": true / false
+}
+```
+
+* The Target Pipeline's name
+* The Role that provides permissions to monitor / trigger the pipeline. This can either be in the same account or in a different account.
+* An optional boolean flag when set to true will attempt to start the pipeline before waiting for it. Defaults to false.
+
+
 ### How it works
-The incoming **UserParameters** object on the AWS CodePipeline invocation event will have the target pipeline name and the ARN of a role with permissions to monitor it.
+
+
 Invoking the lambda from a pipeline will:
 * Assume the cross account role
 * Generate secure temporary credentials using that role.
-* Find the status of the target pipeline
-* Send a continuation token to the invoking pipeline if the target pipeline is still in progress. Which will cause the invoking pipeline to poll the lambda periodically until the target pipeline succeeds.
+* If trigger option is enabled, then start the target pipeline with a new execution.
+* Find the status of the target pipeline.
+* Send a [Continuation Token](https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-invoke-lambda-function.html) to the invoking pipeline if the target pipeline is still in progress. Which will cause the invoking pipeline to poll the lambda periodically until the target pipeline succeeds.
 * Send a failure / success signal to the invoking pipeline if the target pipeline has failed or succeeded.
 
-## Getting started
+
+## Contributing
 ### Prerequisites
-To clone and run this application, you'll need Git, Node.js and npm installed. You can also use an alternative package manager, such as Yarn if you prefer!
+To clone and contribute to this application, you'll need Git, Node.js and [Yarn](https://yarnpkg.com/) installed. You can also use an alternative package manager, such as NPM if you prefer!
 
 ### Installing
 From your favourite command line tool, run the following:
 ```bash
 # Clone the repo
-git clone https://github.com/MetOffice/pipeline-monitor-lambda.git
+git clone git@github.com:xavier-thomas/aws-codepipeline-waiter.git
+
+## or if you use HTTPS instead of SSH
+git clone https://github.com/xavier-thomas/aws-codepipeline-waiter.git
 
 # Install dependencies
-npm ci
+yarn
 ```
 
 ### Running tests
 From your favourite command line tool, run the following:
 ```bash
 # Run the unit tests
-npm test
+yarn test
+```
+
+### Running Mutation Tests
+This project uses [Stryker](https://stryker-mutator.io/) for mutation testing.
+From your favourite command line tool, run the following:
+```bash
+# Mutate and test the unit tests
+yarn mutate
 ```
 
 ### Linting & code formatting
 From your favourite command line tool, run the following:
 ```bash
 # Run the linter
-$ npm run lint
+yarn lint
 ```
 
-## Invoking the Lambda
-### Inputs
-The lambda expects the following UserParameters to be supplied during invocation:
-```JSON
-{
-    "targetname": "target-pipeline-name",
-	"assumerolename": "arn:aws:iam::${AccountId}:role/PipelineMonitoringRole-${Tier}",
-	"trigger": true / false
-}
-```
+### Raising Issues
+We welcome anyone to contribute to this project.
+Before raising a PR, reach out to us by [raising an issue](https://github.com/xavier-thomas/aws-codepipeline-waiter/issues) or by emailing the author.
+There is a helpful issue template that can be used as a guideline to report issues or suggest new features.
+
+### Raising PRs
+
+Once you are satisfied with your work, you can raise a [Pull Request](https://github.com/xavier-thomas/aws-codepipeline-waiter/pulls).
+The project's maintainers will need to approve this before it can be merged in and atleast 1 approving review is needed before your work can be merged in.
+
+`Note`: Pre-Commit hooks are in place to perform audit, lint fix and run tests before you can commit. To ensure that unverified changes are not merged into master, when a new PR is raised on GitHub, the github actions workflow automatically runs the unit tests, mutation tests, [Sonar](https://sonarcloud.io/) and [cfn-lint](https://github.com/aws-cloudformation/cfn-python-lint) to validate the PR. Without successful checks, your pull request will be blocked from being merged as a safeguard.
+
 
 ## Authors
 **[Xavier Thomas](https://github.com/xavier-thomas)**

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The lambda expects the following UserParameters to be supplied during invocation
 ```JSON
 {
     "targetname": "target-pipeline-name",
-    "assumerolename": "arn:aws:iam::${AccountId}:role/PipelineMonitoringRole-${Tier}"
+	"assumerolename": "arn:aws:iam::${AccountId}:role/PipelineMonitoringRole-${Tier}",
+	"trigger": true / false
 }
 ```
 

--- a/codepipeline-waiter.yaml
+++ b/codepipeline-waiter.yaml
@@ -22,7 +22,7 @@ Metadata:
     LicenseUrl: LICENSE
     Name: CodePipeline-Waiter
     ReadmeUrl: README.md
-    SemanticVersion: 1.2.2
+    SemanticVersion: 2.0.0
     SourceCodeUrl: https://github.com/xavier-thomas/aws-codepipeline-waiter
     SpdxLicenseId: BSD-3-Clause
 

--- a/codepipeline-waiter.yaml
+++ b/codepipeline-waiter.yaml
@@ -3,6 +3,13 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
 
+Parameters:
+  ExportPrefix:
+    Description: A optional unique prefix given to the export names
+    Type: String
+    Default: ""
+
+
 Metadata:
   AWS::ServerlessRepo::Application:
     Author: Xavier Thomas
@@ -54,9 +61,9 @@ Outputs:
   PipelineWaiterLambdaArn:
     Value: !GetAtt PipelineWaiterLambda.Arn
     Export:
-      Name: !Sub ${AWS::StackName}-PipelineWaiterLambdaArn
+      Name: !Sub ${ExportPrefix}PipelineWaiterLambdaArn
 
   PipelineWaiterLambdaName:
     Value: !Ref PipelineWaiterLambda
     Export:
-      Name: !Sub ${AWS::StackName}-PipelineWaiterLambdaName
+      Name: !Sub ${ExportPrefix}PipelineWaiterLambdaName

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-codepipeline-waiter",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "An AWS lambda for a deployment AWS code-pipeline to monitor and wait for another pipeline.",
   "main": "src/index.js",
   "keywords": [

--- a/src/codePipeline.js
+++ b/src/codePipeline.js
@@ -4,8 +4,14 @@ let CodePipeline;
 
 /**
  * Notifies AWS CodePipeline if the target pipeline has failed
- * @param {object} event: The AWS event object
- * @param {object} context: The AWS context object
+ * @param {Object} event :Code Pipeline Lambda Invoke Event
+ * https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-Lambda.html#action-reference-Lambda-event
+ * @param {string} event.targetname - The name of the Child / Slave Pipeline to wait for
+ * @param {string} event.assumerolename - The name of the monitoring role to assume. This can be a role in another AWS account for Cross Account trigger & waiter
+ * @param {boolean} event.trigger - Should be Child Pipeline be started first before waiting for it.
+ *
+ * @param {Object} context :Lambda Invoke Context
+ * https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html
  * @param {string} message: A message to describe the failure
  * @returns {promise} :HTTPS Status 200 and empty body
  */
@@ -25,7 +31,13 @@ const notifyFailedJob = async (event, context, message) => {
 /**
  * Notifies AWS CodePipeline if the target pipeline has completed
  * successfully
- * @param {object} event: The AWS event object
+ * @param {Object} event :Code Pipeline Lambda Invoke Event
+ * https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-Lambda.html#action-reference-Lambda-event
+ * @param {string} event.targetname - The name of the Child / Slave Pipeline to wait for
+ * @param {string} event.assumerolename - The name of the monitoring role to assume. This can be a role in another AWS account for Cross Account trigger & waiter
+ * @param {boolean} event.trigger - Should be Child Pipeline be started first before waiting for it.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html
  * @returns {promise} :HTTPS Status 200 and empty body
  */
 const notifySuccessfulJob = async (event) => {
@@ -38,7 +50,12 @@ const notifySuccessfulJob = async (event) => {
 
 /**
  * Notifies AWS CodePipeline if the target pipeline is still in progresss
- * @param {object} event: The AWS event object
+ * @param {Object} event :Code Pipeline Lambda Invoke Event
+ * https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-Lambda.html#action-reference-Lambda-event
+ * @param {string} event.targetname - The name of the Child / Slave Pipeline to wait for
+ * @param {string} event.assumerolename - The name of the monitoring role to assume. This can be a role in another AWS account for Cross Account trigger & waiter
+ * @param {boolean} event.trigger - Should be Child Pipeline be started first before waiting for it.
+ *
  * @returns {promise} :HTTPS Status 200 and empty body
  */
 const continueJobLater = async (event) => {
@@ -52,7 +69,7 @@ const continueJobLater = async (event) => {
 
 /**
  * Get the execution status of the latest run of a given AWS CodePipeline
- * @param {object} targetName: The name of the target AWS CodePipeline
+ * @param {string} targetName: The name of the target AWS CodePipeline
  * @param {object} credentials: The AWS Credentials object with the correct cross account permisions
  * @returns {object} pipelineState: Returns the Pipeline State
  */
@@ -66,7 +83,7 @@ const getPipelineState = async (targetName, credentials) => {
 
 /**
  * Start an execution of a given AWS CodePipeline
- * @param {object} targetName: The name of the target AWS CodePipeline
+ * @param {string} targetName: The name of the target AWS CodePipeline
  * @param {object} credentials: The AWS Credentials object with the correct cross account permissions
  */
 const triggerPipelineRelease = async (targetName, credentials) => {

--- a/src/codePipeline.js
+++ b/src/codePipeline.js
@@ -64,7 +64,21 @@ const getPipelineState = async (targetName, credentials) => {
 	return CodePipeline.getPipelineState(options).promise();
 };
 
+/**
+ * Start an execution of a given AWS CodePipeline
+ * @param {object} targetName: The name of the target AWS CodePipeline
+ * @param {object} credentials: The AWS Credentials object with the correct cross account permissions
+ */
+const triggerPipelineRelease = async (targetName, credentials) => {
+	CodePipeline = new AWS.CodePipeline({ credentials: credentials });
+	const options = {
+		name: targetName,
+	};
+	return CodePipeline.startPipelineExecution(options).promise();
+};
+
 module.exports.notifyFailedJob = notifyFailedJob;
 module.exports.notifySuccessfulJob = notifySuccessfulJob;
 module.exports.continueJobLater = continueJobLater;
 module.exports.getPipelineState = getPipelineState;
+module.exports.triggerPipelineRelease = triggerPipelineRelease;

--- a/src/codePipeline.test.js
+++ b/src/codePipeline.test.js
@@ -5,16 +5,24 @@ import {
 	MOCK_EVENT,
 	MOCK_INVOKE_ID,
 	MOCK_PIPELINE_ID,
+	MOCK_PIPELINE_START_RESULT,
 	MOCK_SUCCESSFUL_PIPELINE_STATE,
 	MOCK_TARGET_NAME,
 } from './mocks';
-import { continueJobLater, getPipelineState, notifyFailedJob, notifySuccessfulJob } from './codePipeline';
+import {
+	continueJobLater,
+	getPipelineState,
+	notifyFailedJob,
+	notifySuccessfulJob,
+	triggerPipelineRelease,
+} from './codePipeline';
 import AWS from 'aws-sdk';
 
 describe('[codePipeline.js] unit tests', () => {
 	const mock_getPipelineState = jest.fn();
 	const mock_putJobFailureResult = jest.fn();
 	const mock_putJobSuccessResult = jest.fn();
+	const mock_startPipelineExecution = jest.fn();
 
 	beforeEach(() => {
 		jest.restoreAllMocks();
@@ -22,6 +30,7 @@ describe('[codePipeline.js] unit tests', () => {
 			getPipelineState: mock_getPipelineState,
 			putJobFailureResult: mock_putJobFailureResult,
 			putJobSuccessResult: mock_putJobSuccessResult,
+			startPipelineExecution: mock_startPipelineExecution,
 		}));
 	});
 
@@ -87,6 +96,22 @@ describe('[codePipeline.js] unit tests', () => {
 				name: MOCK_TARGET_NAME,
 			});
 			expect(response).toEqual(MOCK_SUCCESSFUL_PIPELINE_STATE);
+		});
+	});
+
+	describe('[triggerPipelineRelease] when a valid target and credentials are passed', () => {
+		it('must trigger an execution of an AWS CodePipeline', async () => {
+			mock_startPipelineExecution.mockReturnValue({
+				promise: jest.fn().mockResolvedValue(MOCK_PIPELINE_START_RESULT),
+			});
+			const response = await triggerPipelineRelease(MOCK_TARGET_NAME, MOCK_CREDENTIALS_OBJECT);
+			expect(AWS.CodePipeline).toHaveBeenCalledWith({
+				credentials: MOCK_CREDENTIALS_OBJECT,
+			});
+			expect(mock_startPipelineExecution).toHaveBeenCalledWith({
+				name: MOCK_TARGET_NAME,
+			});
+			expect(response).toEqual(MOCK_PIPELINE_START_RESULT);
 		});
 	});
 });

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import {
  * @param {Object} event :Code Pipeline Lambda Invoke Event
  * https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-Lambda.html#action-reference-Lambda-event
  * @param {string} event.targetname - The name of the Child / Slave Pipeline to wait for
- * @param {string} event.assumerolename - The name of the monitoring role to assume. This can be a role in another AWS account for Cross Account trigger & waiter
+ * @param {string} event.assumerolearn - The name of the monitoring role to assume. This can be a role in another AWS account for Cross Account trigger & waiter
  * @param {boolean} event.trigger - Should be Child Pipeline be started first before waiting for it.
  *
  * @param {Object} context :Lambda Invoke Context
@@ -32,7 +32,7 @@ exports.handler = async (event, context) => {
 	if (userParameters) {
 		try {
 			const isTriggered = userParameters.trigger ? userParameters.trigger : false;
-			const data = await assumeRole(userParameters.assumerolename);
+			const data = await assumeRole(userParameters.assumerolearn);
 			const credentials = await getCredentials(data);
 
 			if (isTriggered) {

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -5,7 +5,7 @@ export const MOCK_ASSUMED_ROLE_DATA = {
 		RequestId: 'a817893e-9b25-11e8-90e6-6f826b9ef79a',
 	},
 	AssumedRoleUser: {
-		Arn: 'arn:aws:sts::123456789012:assumed-role/FakeRole/PipelineMonitoringLambda',
+		Arn: 'arn:aws:sts::123456789012:assumed-role/FakeRole/PipelineWaiterLambda',
 		AssumedRoleId: 'ARO123EXAMPLE123:FakeRole',
 	},
 	Credentials: {

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -143,3 +143,7 @@ export const MOCK_PENDING_PIPELINE_STATE = {
 		},
 	],
 };
+
+export const MOCK_PIPELINE_START_RESULT = {
+	pipelineExecutionId: 'aapban-awdasda-bawsawd-avasadw',
+};

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -42,6 +42,18 @@ export const MOCK_USER_PARAMETERS = {
 	targetname: MOCK_TARGET_NAME,
 };
 
+export const MOCK_USER_PARAMETERS_TRIGGER_TRUE = {
+	assumerolename: MOCK_ASSUME_ROLE_ARN,
+	targetname: MOCK_TARGET_NAME,
+	trigger: true,
+};
+
+export const MOCK_USER_PARAMETERS_TRIGGER_FALSE = {
+	assumerolename: MOCK_ASSUME_ROLE_ARN,
+	targetname: MOCK_TARGET_NAME,
+	trigger: false,
+};
+
 export const MOCK_PIPELINE_ID = '2989f000-275f-4031-82bf-cab460511cc4';
 
 export const MOCK_INVOKE_ID = '15c14512-62df-4db4-8588-9c786c572a83';
@@ -52,6 +64,32 @@ export const MOCK_EVENT = {
 			actionConfiguration: {
 				configuration: {
 					UserParameters: JSON.stringify(MOCK_USER_PARAMETERS),
+				},
+			},
+		},
+		id: MOCK_PIPELINE_ID,
+	},
+};
+
+export const MOCK_EVENT_TRIGGER_TRUE = {
+	'CodePipeline.job': {
+		data: {
+			actionConfiguration: {
+				configuration: {
+					UserParameters: JSON.stringify(MOCK_USER_PARAMETERS_TRIGGER_TRUE),
+				},
+			},
+		},
+		id: MOCK_PIPELINE_ID,
+	},
+};
+
+export const MOCK_EVENT_TRIGGER_FALSE = {
+	'CodePipeline.job': {
+		data: {
+			actionConfiguration: {
+				configuration: {
+					UserParameters: JSON.stringify(MOCK_USER_PARAMETERS_TRIGGER_FALSE),
 				},
 			},
 		},

--- a/src/sts.js
+++ b/src/sts.js
@@ -11,7 +11,7 @@ const assumeRole = async (assumeRoleArn) => {
 	STS = new AWS.STS();
 	const options = {
 		RoleArn: assumeRoleArn,
-		RoleSessionName: 'PipelineMonitoringLambda',
+		RoleSessionName: 'PipelineWaiterLambda',
 	};
 	return STS.assumeRole(options).promise();
 };

--- a/src/sts.js
+++ b/src/sts.js
@@ -4,7 +4,7 @@ let STS;
 
 /**
  * Assumes a cross account role and returns the AWS credentials object.
- * @param {object} assumeRoleArn: The ARN of the AWS IAM role
+ * @param {string} assumeRoleArn: The ARN of the AWS IAM role
  * @returns {object} :The Data returned by the STS Assume Role API call
  */
 const assumeRole = async (assumeRoleArn) => {
@@ -18,7 +18,7 @@ const assumeRole = async (assumeRoleArn) => {
 
 /**
  * Assumes a cross account role and returns the AWS credentials object.
- * @param {object} assumeRoleData: The Data returned by the STS Assume Role API call
+ * @param {string} assumeRoleData: The Data returned by the STS Assume Role API call
  * @returns {object} :The Credentials Object returned by AWS STS.GetCredentials
  */
 const getCredentials = async (assumeRoleData) => {

--- a/src/sts.test.js
+++ b/src/sts.test.js
@@ -27,7 +27,7 @@ describe('[sts.js] unit tests', () => {
 			const response = await assumeRole(MOCK_ASSUME_ROLE_ARN);
 			expect(mockAssumeRole).toHaveBeenCalledWith({
 				RoleArn: MOCK_ASSUME_ROLE_ARN,
-				RoleSessionName: 'PipelineMonitoringLambda',
+				RoleSessionName: 'PipelineWaiterLambda',
 			});
 			expect(response).toEqual(MOCK_ASSUMED_ROLE_DATA);
 		});


### PR DESCRIPTION
# Description

closes https://github.com/xavier-thomas/aws-codepipeline-waiter/issues/5

### 2.0.0
#### Added
- Conditional Ability to Trigger a child pipeline before waiting for it.
#### Changed
- Updated Documentation.

## Type of change
- [X] :rocket: New feature (non-breaking change which adds functionality)
- [X] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] :notebook: Documentation update

# Checklist:

#### Versioning
- [X] `Changelog` has been updated in the root directory
- [X] Version updated on `package.json` in the root directory
- [X] Version updated in the `codepipeline-waiter.yaml`

#### PR Etiquette
- [X] I've added labels to my PR to describe the change.

#### Sanity
- [X] I have performed a self-review of my own code
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

#### Testing
- [X] Linting passing locally
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Unit testing passing locally
- [X] Mutation testing is passing locally
- [X] Integration tests & End to End tests are passing

#### Code Quality
- [X] Errors and handled and Logged
- [X] Types added to all method signatures and parameters
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] Sonar analysis is passing
